### PR TITLE
properly append arguments to the run command

### DIFF
--- a/api/v1alpha1/k6_types.go
+++ b/api/v1alpha1/k6_types.go
@@ -20,11 +20,11 @@ import (
 
 // K6Spec defines the desired state of K6
 type K6Spec struct {
-	Script      string  `json:"script"`
-	Parallelism int32   `json:"parallelism"`
-	Separate    bool    `json:"separate,omitempty"`
-//	Cleanup     Cleanup `json:"cleanup,omitempty"` // TODO
-	Arguments   string  `json:"arguments,omitempty"`
+	Script      string `json:"script"`
+	Parallelism int32  `json:"parallelism"`
+	Separate    bool   `json:"separate,omitempty"`
+	Arguments   string `json:"arguments,omitempty"`
+	//	Cleanup     Cleanup `json:"cleanup,omitempty"` // TODO
 }
 
 // Cleanup allows for automatic cleanup of resources pre or post execution

--- a/config/samples/k6_v1alpha1_k6_with_output.yaml
+++ b/config/samples/k6_v1alpha1_k6_with_output.yaml
@@ -1,0 +1,8 @@
+apiVersion: k6.io/v1alpha1
+kind: K6
+metadata:
+  name: k6-sample
+spec:
+  parallelism: 4
+  script: k6-test
+  arguments: --out kafka=brokers=kafka-host:9092,topic=test-output,format=json

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -7,6 +7,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strings"
 )
 
 // NewRunnerJob creates a new k6 job from a CRD
@@ -26,7 +27,8 @@ func NewRunnerJob(k *v1alpha1.K6, index int) (*batchv1.Job, error) {
 	}
 
 	if k.Spec.Arguments != "" {
-		command = append(command, k.Spec.Arguments)
+		args := strings.Split(k.Spec.Arguments, " ")
+		command = append(command, args...)
 	}
 	command = append(
 		command,


### PR DESCRIPTION
- adds a sample manifest with an output as argument
- fixes an issue where arguments where appended as a full string instead of a segmented array