### PR TITLE
Update auth_proxy_client_clusterrole.yaml

### DIFF
--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -37,6 +37,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - k6.io
   resources:


### PR DESCRIPTION
ClusterRole v1beta1 is deprecated, and soon unavailable.

```
clusterrole.rbac.authorization.k8s.io/k6-operator-proxy-role created
Warning: rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
```