### PR TITLE
Add support for job environment

### DIFF
--- a/api/v1alpha1/k6_types.go
+++ b/api/v1alpha1/k6_types.go
@@ -15,15 +15,17 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // K6Spec defines the desired state of K6
 type K6Spec struct {
-	Script      string `json:"script"`
-	Parallelism int32  `json:"parallelism"`
-	Separate    bool   `json:"separate,omitempty"`
-	Arguments   string `json:"arguments,omitempty"`
+	Script      string          `json:"script"`
+	Parallelism int32           `json:"parallelism"`
+	Separate    bool            `json:"separate,omitempty"`
+	Arguments   string          `json:"arguments,omitempty"`
+	Env         []corev1.EnvVar `json:"env,omitempty"`
 	//	Cleanup     Cleanup `json:"cleanup,omitempty"` // TODO
 }
 

--- a/pkg/resources/jobs/runner.go
+++ b/pkg/resources/jobs/runner.go
@@ -3,12 +3,13 @@ package jobs
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/k6io/operator/api/v1alpha1"
 	"github.com/k6io/operator/pkg/segmentation"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 // NewRunnerJob creates a new k6 job from a CRD
@@ -56,6 +57,7 @@ func NewRunnerJob(k *v1alpha1.K6, index int) (*batchv1.Job, error) {
 						Image:   "loadimpact/k6:latest",
 						Name:    "k6",
 						Command: command,
+						Env:     k.Spec.Env,
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "k6-test-volume",
 							MountPath: "/test",


### PR DESCRIPTION
Simply add the `Env` property to the CRD, and pass that to the K6 job spec. This should enable uses cases such as #15 